### PR TITLE
Checking for require function with typeof operator

### DIFF
--- a/moment.easter.js
+++ b/moment.easter.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var moment;
-if (require !== undefined) {
+if (typeof require !== 'undefined') {
     moment = require('moment');
 } else {
     moment = this.moment;
@@ -100,7 +100,7 @@ moment.fn.easter = function () {
     return moment.easter(this.year());
 };
 
-if (module !== undefined) {
+if (typeof module !== 'undefined') {
     module.exports = moment;
 } else {
     this.moment = moment;


### PR DESCRIPTION
Webpack throws warning about misused require function, when checking for it
directly and not with typeof operator.
